### PR TITLE
Change base image from tianon/raspbian:bullseye-slim to navikey/raspbian-bullseye

### DIFF
--- a/UCTronics_OLED_Display_Python/build.json
+++ b/UCTronics_OLED_Display_Python/build.json
@@ -2,7 +2,7 @@
     "image": "homeassistant/armhf-base-raspbian",
     "shadow_repository": "ghcr.io/home-assistant",
     "build_from": {
-        "armhf": "navikey/raspbian-bullseye"
+        "armhf": "raspbian/jessie"
     },
     "args": {
         "BASHIO_VERSION": "0.13.1",

--- a/UCTronics_OLED_Display_Python/build.json
+++ b/UCTronics_OLED_Display_Python/build.json
@@ -2,7 +2,7 @@
     "image": "homeassistant/armhf-base-raspbian",
     "shadow_repository": "ghcr.io/home-assistant",
     "build_from": {
-        "armhf": "tianon/raspbian:buster-slim"
+        "armhf": "navikey/raspbian-bullseye"
     },
     "args": {
         "BASHIO_VERSION": "0.13.1",

--- a/UCTronics_OLED_Display_Python/build.json
+++ b/UCTronics_OLED_Display_Python/build.json
@@ -2,7 +2,7 @@
     "image": "homeassistant/armhf-base-raspbian",
     "shadow_repository": "ghcr.io/home-assistant",
     "build_from": {
-        "armhf": "tianon/raspbian:bullseye-slim"
+        "armhf": "tianon/raspbian:buster-slim"
     },
     "args": {
         "BASHIO_VERSION": "0.13.1",

--- a/UCTronics_OLED_Display_Python/build.json
+++ b/UCTronics_OLED_Display_Python/build.json
@@ -1,9 +1,7 @@
 {
     "image": "homeassistant/armhf-base-raspbian",
     "shadow_repository": "ghcr.io/home-assistant",
-    "build_from": {
-        "armhf": "raspbian/jessie"
-    },
+    "build_from": "homeassistant/amd64-base",
     "args": {
         "BASHIO_VERSION": "0.13.1",
         "TEMPIO_VERSION": "2021.05.0",

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
     "name": "Home Assistant Add-ons:",
-    "url": "https://github.com/UCTRONICS/HomeAssistant",
-    "maintainer": "UCTRONICS <support@uctronics.com>"
+    "url": "https://github.com/LordPsycho202/HomeAssistant",
+    "maintainer": "rnissen <rnissen@thejiraguy.com>"
 }


### PR DESCRIPTION
Updating the base image so that the add-on will work with arm64 based HASSIO images